### PR TITLE
Export unordered as a SendmsgFlag as well

### DIFF
--- a/socket-sctp.cabal
+++ b/socket-sctp.cabal
@@ -19,6 +19,8 @@ tested-with:         GHC==7.10.1, GHC==7.8.3
 extra-source-files:  README.md
                      CHANGELOG.md
                      CONTRIBUTORS.txt
+                     src/System/Socket/Protocol/SCTP/hs_sctp.c
+                     src/System/Socket/Protocol/SCTP/hs_sctp.h
 
 library
   ghc-options:         -Wall
@@ -26,8 +28,11 @@ library
   other-modules:       System.Socket.Protocol.SCTP.Internal
   build-depends:       base >= 4.7 && < 5
                      , bytestring < 0.11
-                     , socket >= 0.5.1.0 && < 0.6.0.0
+                     , socket >= 0.7.0.0 && < 0.8
   hs-source-dirs:      src
+  include-dirs:        src/System/Socket/Protocol/SCTP
+  c-sources:           src/System/Socket/Protocol/SCTP/hs_sctp.c
+  install-includes:    src/System/Socket/Protocol/SCTP/hs_sctp.h
   build-tools:         hsc2hs
   default-language:    Haskell2010
   extra-libraries:     sctp

--- a/socket-sctp.cabal
+++ b/socket-sctp.cabal
@@ -35,7 +35,8 @@ library
   install-includes:    src/System/Socket/Protocol/SCTP/hs_sctp.h
   build-tools:         hsc2hs
   default-language:    Haskell2010
-  extra-libraries:     sctp
+  if !os(freebsd)
+    extra-libraries:   sctp
 
 source-repository head
   type:                git

--- a/socket-sctp.cabal
+++ b/socket-sctp.cabal
@@ -61,3 +61,14 @@ test-suite TooSmallBuffer
                      , bytestring < 0.11
                      , socket
                      , socket-sctp
+
+test-suite SendAll
+  hs-source-dirs:      tests
+  main-is:             SendAll.hs
+  type:                exitcode-stdio-1.0
+  default-language:    Haskell2010
+  build-tools:         hsc2hs
+  build-depends:       base >= 4.7 && < 5
+                     , bytestring < 0.11
+                     , socket
+                     , socket-sctp

--- a/src/System/Socket/Protocol/SCTP.hsc
+++ b/src/System/Socket/Protocol/SCTP.hsc
@@ -63,7 +63,7 @@ import System.Socket.Protocol.SCTP.Internal
 -- >     "Hello world!"
 -- >     ( SocketAddressInet Inet.loopback 7777 )
 -- >     ( 2342   :: PayloadProtocolIdentifier )
--- >     ( mempty :: MessageFlags )
+-- >     ( mempty :: SendmsgFlags )
 -- >     ( 2      :: StreamNumber )
 -- >     ( 0      :: TimeToLive )
 -- >     ( 0      :: Context )

--- a/src/System/Socket/Protocol/SCTP/Internal.hsc
+++ b/src/System/Socket/Protocol/SCTP/Internal.hsc
@@ -17,10 +17,12 @@ module System.Socket.Protocol.SCTP.Internal
   , TransportSequenceNumber (..)
   , CumulativeTransportSequenceNumber (..)
   , AssociationIdentifier (..)
+  -- * SendmsgFlags
   , SendmsgFlags (..)
 #ifdef SCTP_SENDALL
   , sendall
 #endif
+  , unorderedSendmsg
   -- * SendReceiveInfoFlags
   , SendReceiveInfoFlags (..)
   -- ** unordered
@@ -148,6 +150,9 @@ shutdown         = SendReceiveInfoFlags (#const SCTP_EOF)
 sendall         :: SendmsgFlags
 sendall          = SendmsgFlags (#const SCTP_SENDALL)
 #endif
+
+unorderedSendmsg :: SendmsgFlags
+unorderedSendmsg = SendmsgFlags (#const SCTP_UNORDERED)
 
 instance Storable SendReceiveInfo where
   sizeOf    _ = (#size struct sctp_sndrcvinfo)

--- a/src/System/Socket/Protocol/SCTP/hs_sctp.c
+++ b/src/System/Socket/Protocol/SCTP/hs_sctp.c
@@ -1,0 +1,22 @@
+#include <errno.h>
+#include "hs_sctp.h"
+
+int hs_sctp_sendmsg(int sd, const void * msg, size_t len,
+                    struct sockaddr *to, socklen_t tolen,
+                    uint32_t ppid, uint32_t flags,
+                    uint16_t stream_no, uint32_t timetolive,
+                    uint32_t context, int *err) {
+  int i = sctp_sendmsg(sd, msg, len, to, tolen, ppid, flags,
+                       stream_no, timetolive, context);
+  *err = errno;
+  return i;
+}
+
+int hs_sctp_recvmsg(int sd, void * msg, size_t len,
+                    struct sockaddr * from, socklen_t * fromlen,
+                    struct sctp_sndrcvinfo * sinfo, int * msg_flags,
+                    int *err) {
+  int i = sctp_recvmsg(sd, msg, len, from, fromlen, sinfo, msg_flags);
+  *err = errno;
+  return i;
+}

--- a/src/System/Socket/Protocol/SCTP/hs_sctp.h
+++ b/src/System/Socket/Protocol/SCTP/hs_sctp.h
@@ -1,0 +1,14 @@
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/sctp.h>
+
+int hs_sctp_sendmsg(int sd, const void * msg, size_t len,
+                    struct sockaddr *to, socklen_t tolen,
+                    uint32_t ppid, uint32_t flags,
+                    uint16_t stream_no, uint32_t timetolive,
+                    uint32_t context, int *err);
+
+int hs_sctp_recvmsg(int sd, void * msg, size_t len,
+                    struct sockaddr * from, socklen_t * fromlen,
+                    struct sctp_sndrcvinfo * sinfo, int * msg_flags,
+                    int *err);

--- a/tests/SendAll.hsc
+++ b/tests/SendAll.hsc
@@ -1,0 +1,45 @@
+{-# LANGUAGE OverloadedStrings #-}
+#include "netinet/sctp.h"
+#ifdef SCTP_SENDALL
+module Main where
+
+import System.Socket
+import System.Socket.Type.SequentialPacket
+import System.Socket.Protocol.SCTP as SCTP
+import System.Socket.Family.Inet as Inet
+import Control.Monad
+
+main :: IO ()
+main = do
+  server <- socket :: IO (Socket Inet SequentialPacket SCTP)
+  client1 <- socket :: IO (Socket Inet SequentialPacket SCTP)
+  client2 <- socket :: IO (Socket Inet SequentialPacket SCTP)
+  bind server addr
+  listen server 5
+  connect client1 addr
+  connect client2 addr
+  SCTP.sendMessage
+    server
+    "hallo"
+    Nothing
+    0
+    sendall
+    0
+    3
+    0
+  (msg1, _, _, _) <- SCTP.receiveMessage client1 4096 mempty
+  when (msg1 /= "hallo") (error "0")
+  (msg2, _, _, _) <- SCTP.receiveMessage client2 4096 mempty
+  when (msg2 /= "hallo") (error "1")
+
+addr :: SocketAddress Inet
+addr  = SocketAddressInet Inet.inetLoopback 7777
+
+#else
+
+module Main where
+
+main :: IO ()
+main = return ()
+
+#endif

--- a/tests/SendReceiveMessage.hs
+++ b/tests/SendReceiveMessage.hs
@@ -24,9 +24,9 @@ main = do
   SCTP.sendMessage
     client
     "hallo"
-    addr
+    (Just addr)
     ( 2342   :: PayloadProtocolIdentifier )
-    ( mempty :: MessageFlags )
+    ( mempty :: SendmsgFlags )
     ( 2      :: StreamNumber )
     ( 3      :: TimeToLive )
     ( 4      :: Context )           `onException` p 7

--- a/tests/SendReceiveMessage.hs
+++ b/tests/SendReceiveMessage.hs
@@ -7,6 +7,7 @@ import Control.Exception
 import Control.Concurrent
 
 import System.Socket
+import System.Socket.Type.SequentialPacket
 import System.Socket.Family.Inet as Inet
 import System.Socket.Protocol.SCTP as SCTP
 
@@ -37,8 +38,8 @@ main = do
   when (msg /= "hallo") (e 11)
   when (flags /= msgEndOfRecord) (e 12)
 
-addr :: SocketAddressInet
-addr  = SocketAddressInet Inet.loopback 7777
+addr :: SocketAddress Inet
+addr  = SocketAddressInet Inet.inetLoopback 7777
 
 p :: Int -> IO ()
 p i = print i

--- a/tests/TooSmallBuffer.hs
+++ b/tests/TooSmallBuffer.hs
@@ -24,9 +24,9 @@ main = do
   SCTP.sendMessage
     client
     "hallowelt"
-    addr
+    (Just addr)
     ( 2342   :: PayloadProtocolIdentifier )
-    ( mempty :: MessageFlags )
+    ( mempty :: SendmsgFlags )
     ( 2      :: StreamNumber )
     ( 3      :: TimeToLive )
     ( 4      :: Context )           `onException` p 7

--- a/tests/TooSmallBuffer.hs
+++ b/tests/TooSmallBuffer.hs
@@ -7,6 +7,7 @@ import Control.Exception
 import Control.Concurrent
 
 import System.Socket
+import System.Socket.Type.SequentialPacket
 import System.Socket.Family.Inet as Inet
 import System.Socket.Protocol.SCTP as SCTP
 
@@ -44,8 +45,8 @@ main = do
   when (msg' /= "welt") (e 16)
   when (flags' /= msgEndOfRecord) (e 17)
 
-addr :: SocketAddressInet
-addr  = SocketAddressInet Inet.loopback 7777
+addr :: SocketAddress Inet
+addr  = SocketAddressInet Inet.inetLoopback 7777
 
 p :: Int -> IO ()
 p i = print i


### PR DESCRIPTION
On top of #8 because it defines the SendmsgFlag type.